### PR TITLE
Add `check_ptype` arg

### DIFF
--- a/R/pr-predict.R
+++ b/R/pr-predict.R
@@ -6,6 +6,9 @@
 #' @param pr A Plumber router, such as from [plumber::pr()].
 #' @param vetiver_model A deployable [vetiver_model()] object
 #' @param ... Other arguments passed to `predict()`, such as prediction `type`
+#' @param check_ptype Should the `ptype` stored in `vetiver_model` (used for
+#' visual API documentation) also be used to check new data at prediction time?
+#' Defaults to `TRUE`.
 #' @param all_docs Should the interactive visual API documentation be created
 #' for _all_ POST endpoints in the router `pr`? This defaults to `TRUE`, and
 #' assumes that all POST endpoints use the `vetiver_model$ptype` input data
@@ -70,7 +73,8 @@ vetiver_pr_post <- function(pr,
                             vetiver_model,
                             path = "/predict",
                             debug = is_interactive(),
-                            ...) {
+                            ...,
+                            check_ptype = TRUE) {
     # `force()` all `...` arguments early; https://github.com/tidymodels/vetiver/pull/20
     rlang::list2(...)
     handler_startup(vetiver_model)
@@ -86,6 +90,9 @@ vetiver_pr_post <- function(pr,
             path = "/pin-url",
             function() vetiver_model$metadata$url
         )
+    }
+    if (!check_ptype) {
+        vetiver_model$ptype <- NULL
     }
     pr <- plumber::pr_post(
         pr,

--- a/R/vetiver-model.R
+++ b/R/vetiver-model.R
@@ -14,9 +14,9 @@
 #' description of the model will be generated.
 #' @param save_ptype Should an input data prototype be stored with the model?
 #' The options are `TRUE` (the default, which stores a zero-row slice of the
-#' training data), `FALSE` (no input data prototype for checking), or a
-#' dataframe to be used for both checking at prediction time *and* examples in
-#' API visual documentation.
+#' training data), `FALSE` (no input data prototype for visual documentation or
+#' checking), or a dataframe to be used for both checking at prediction time
+#' *and* examples in API visual documentation.
 #' @param ptype An input data prototype. If `NULL`, there is no checking of
 #' new data at prediction time.
 #' @param versioned Should the model object be versioned when stored with

--- a/man/vetiver_create_ptype.Rd
+++ b/man/vetiver_create_ptype.Rd
@@ -37,9 +37,9 @@ to compute an input data prototype.}
 
 \item{save_ptype}{Should an input data prototype be stored with the model?
 The options are \code{TRUE} (the default, which stores a zero-row slice of the
-training data), \code{FALSE} (no input data prototype for checking), or a
-dataframe to be used for both checking at prediction time \emph{and} examples in
-API visual documentation.}
+training data), \code{FALSE} (no input data prototype for visual documentation or
+checking), or a dataframe to be used for both checking at prediction time
+\emph{and} examples in API visual documentation.}
 }
 \value{
 A \code{vetiver_ptype} method returns a zero-row dataframe, and

--- a/man/vetiver_model.Rd
+++ b/man/vetiver_model.Rd
@@ -35,9 +35,9 @@ avoid potential clashes with the metadata that pins itself uses.}
 
 \item{save_ptype}{Should an input data prototype be stored with the model?
 The options are \code{TRUE} (the default, which stores a zero-row slice of the
-training data), \code{FALSE} (no input data prototype for checking), or a
-dataframe to be used for both checking at prediction time \emph{and} examples in
-API visual documentation.}
+training data), \code{FALSE} (no input data prototype for visual documentation or
+checking), or a dataframe to be used for both checking at prediction time
+\emph{and} examples in API visual documentation.}
 
 \item{versioned}{Should the model object be versioned when stored with
 \code{\link[=vetiver_pin_write]{vetiver_pin_write()}}? The default, \code{NULL}, will use the default for the

--- a/man/vetiver_pr_predict.Rd
+++ b/man/vetiver_pr_predict.Rd
@@ -19,7 +19,8 @@ vetiver_pr_post(
   vetiver_model,
   path = "/predict",
   debug = is_interactive(),
-  ...
+  ...,
+  check_ptype = TRUE
 )
 
 vetiver_pr_docs(pr, vetiver_model, path = "/predict", all_docs = TRUE)
@@ -34,6 +35,10 @@ vetiver_pr_docs(pr, vetiver_model, path = "/predict", all_docs = TRUE)
 \item{debug}{\code{TRUE} provides more insight into your API errors.}
 
 \item{...}{Other arguments passed to \code{predict()}, such as prediction \code{type}}
+
+\item{check_ptype}{Should the \code{ptype} stored in \code{vetiver_model} (used for
+visual API documentation) also be used to check new data at prediction time?
+Defaults to \code{TRUE}.}
 
 \item{all_docs}{Should the interactive visual API documentation be created
 for \emph{all} POST endpoints in the router \code{pr}? This defaults to \code{TRUE}, and

--- a/tests/testthat/_snaps/choose-version.md
+++ b/tests/testthat/_snaps/choose-version.md
@@ -2,7 +2,7 @@
 
     Code
       p <- choose_version(p)
-    Warning <warning>
+    Warning <rlang_warning>
       Pinned vetiver model has no active version and no datetime on versions
       * Do you need to check your pinned model?
       * Using version 4500

--- a/tests/testthat/test-pr-predict.R
+++ b/tests/testthat/test-pr-predict.R
@@ -51,6 +51,20 @@ test_that("OpenAPI spec is the same for modular functions", {
   expect_equal(spec1, spec2)
 })
 
+test_that("OpenAPI spec for check_ptype = FALSE", {
+  p <- pr() %>% vetiver_pr_post(v, check_ptype = FALSE) %>% vetiver_pr_docs(v)
+  expect_equal(names(p$routes), c("ping", "predict"))
+  expect_equal(map_chr(p$routes, "verbs"),
+               c(ping = "GET", predict = "POST"))
+  car_spec <- p$getApiSpec()
+  post_spec <- car_spec$paths$`/predict`$post
+  expect_equal(names(post_spec), c("summary", "requestBody", "responses"))
+  expect_equal(as.character(post_spec$summary),
+               "Return predictions from model using 2 features")
+  expect_equal(names(post_spec$requestBody$content$`application/json`$schema$items),
+               c("type", "properties"))
+})
+
 test_that("OpenAPI spec for save_ptype = FALSE", {
   v1 <- vetiver_model(cars_lm, "cars1", save_ptype = FALSE)
   p <- pr() %>% vetiver_pr_predict(v1)


### PR DESCRIPTION
This PR separates the act of saving a data prototype (`save_ptype` when creating a model) with using that prototype for checking at prediction time (`check_ptype`). The default behavior stays the same but this lets a user add a prototype for visual documentation but not use it for the vetiver checking (just use whatever the model does natively with wrongly typed data).

This change is at least partly to maintain parity with the Python implementation for vetiver.

@isabelizimm can you take a look at this and see if this aligns with what we spoke about?